### PR TITLE
Allow for :memory: sqlite3 path - useful for testing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+### v0.1.4-memory, 2011-09-16 -- Bugfix sqlite3 :memory: path
+* Allow for :memory: sqlite3 path for testing purposes
+
 ### v0.1.4, 2011-08-17 -- Bugfix for get_many unicode issue
 * get_many() and select() no longer miss unicode keys
 

--- a/sqlite3dbm/__init__.py
+++ b/sqlite3dbm/__init__.py
@@ -18,7 +18,7 @@ serialization for it.
 """
 
 __author__ = 'Jason Fennell <jfennell@yelp.com>'
-__version__ = '0.1.4'
+__version__ = '0.1.4-memory'
 
 import sqlite3dbm.dbm as dbm
 import sqlite3dbm.sshelve as sshelve

--- a/sqlite3dbm/dbm.py
+++ b/sqlite3dbm/dbm.py
@@ -199,8 +199,6 @@ class SqliteMap(object):
 
         See `open` for explanation of the parameters.
         """
-        # Need an absolute path to db on the filesystem
-        path = os.path.abspath(path)
 
         if flag not in ('c', 'n', 'w', 'r'):
             raise error('Invalid flag "%s"' % (flag,))
@@ -210,14 +208,19 @@ class SqliteMap(object):
 
         self.readonly = flag == 'r'
 
-        # r and w require the db to exist ahead of time
-        if not os.path.exists(path):
-            if flag in ('r', 'w'):
-                raise error('DB does not exist at %s' % (path,))
-            else:
-                # Ghetto way of respecting mode, since unexposed by sqlite3.connect
-                # Manually create the file before sqlite3 connects to it
-                os.open(path, os.O_CREAT, mode)
+        # Allow for :memory: sqlite3 path for testing purposes
+        if path != ':memory:':
+            # Need an absolute path to db on the filesystem
+            path = os.path.abspath(path)
+
+            # r and w require the db to exist ahead of time
+            if not os.path.exists(path):
+                if flag in ('r', 'w'):
+                    raise error('DB does not exist at %s' % (path,))
+                else:
+                    # Ghetto way of respecting mode, since unexposed by sqlite3.connect
+                    # Manually create the file before sqlite3 connects to it
+                    os.open(path, os.O_CREAT, mode)
 
         self.conn = sqlite3.connect(path)
         self.conn.text_factory = str


### PR DESCRIPTION
Hey Jason, long time no see :)

We're using sqlite3dbm extensively here at Adku and we needed to create a temporary sqlite3map for testing purposes.  To make a throw-away sqlite3map that we can also populate on the fly (think fixtures), we patched in support for the special sqlite3 ":memory:" path.  Hope you guys find this useful too :)

-Matt
