### PR TITLE
Adding multi-map support to a single SQLiteDB

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -5,3 +5,5 @@ Primary authors:
 * Jason Fennell <jfennell@yelp.com>
 
 Contributors (in order of contribution, latest first):
+
+* Matthew Tai <mtai84@gmail.com>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+### v0.2.x-multi-map, 2011-11-09 -- Major version change
+* Added multi-map support to a single SQLite DB
+  * Added SQLiteMapContainer to wrap a SQLite DB with multiple SQLiteMaps
+  * Changed SQLiteMap to be backed by a table not an entire DB
+  * Provided new open_container method sqlite3dbm.dbm
+* Backward compatible with sqlite3dbm 0.1.x generated files
+
 ### v0.1.4-memory, 2011-09-16 -- Bugfix sqlite3 :memory: path
 * Allow for :memory: sqlite3 path for testing purposes
 
@@ -9,7 +16,7 @@
   * update() is faster. Should be preferred over many individual inserts
   * clear() is faster
 
-### v0.1.2, 2011-01-28 -- Bumb version number
+### v0.1.2, 2011-01-28 -- Bump version number
 * Do a full minor bump for pypi
 
 ### v0.1.1a, 2011-01-28 -- Fix MANIFEST

--- a/sqlite3dbm/__init__.py
+++ b/sqlite3dbm/__init__.py
@@ -18,7 +18,7 @@ serialization for it.
 """
 
 __author__ = 'Jason Fennell <jfennell@yelp.com>'
-__version__ = '0.1.4-memory'
+__version__ = '0.2.x-multi-map'
 
 import sqlite3dbm.dbm as dbm
 import sqlite3dbm.sshelve as sshelve

--- a/sqlite3dbm/sshelve.py
+++ b/sqlite3dbm/sshelve.py
@@ -56,7 +56,7 @@ class SqliteMapShelf(shelve.Shelf):
     def __init__(self, smap, protocol=None, writeback=False):
         # Force the Sqlite DB to return bytestrings.  By default it returns
         # unicode by default, which causes Pickle to shit its pants.
-        smap.conn.text_factory = str
+        smap._conn.text_factory = str
 
         # SqliteMapShelf < Shelf < DictMixin which is an old style class :-P
         shelve.Shelf.__init__(self, smap, protocol, writeback)


### PR DESCRIPTION
This might be outside the scope of what sqlite3dbm is trying to accomplish but is something that might be useful nonetheless.  Instead of having to have N dbs for N tables, we can now have a single db support N tables.  Try this out in ipython

import sqlite3dbm.dbm
# New method

map_container = sqlite3dbm.dbm.open_container('hello.db', flag='c')
# Auto-create table on the fly

number_map = map_container.number_map
number_map['12345'] = '6789'
# Auto-create table on the fly again

letter_map = map_container.letter_map
letter_map['abcd'] = 'efgh'

print number_map.items()
print letter_map.items()
print hello.mapnames()

I added a test and changed CHANGES.txt / AUTHORS.txt but didn't update the docs.  I would like this available for everyone to use but would like to hear if/how this should be integrated.
